### PR TITLE
Wrong flag name

### DIFF
--- a/core/runtime.c
+++ b/core/runtime.c
@@ -245,7 +245,7 @@ static void initialize_retained(void) {
 
 /* Waits until capacitor is fully charged as indicated by PWRGD_H pin */
 riotee_rc_t riotee_wait_cap_charged(void) {
-#ifdef DISABLE_CAP_MON
+#ifdef DISABLE_CAP_MONITOR
   return RIOTEE_SUCCESS;
 #else
   return riotee_gpio_wait_level(PIN_PWRGD_H, RIOTEE_GPIO_LEVEL_HIGH, RIOTEE_GPIO_IN_NOPULL);


### PR DESCRIPTION
In all cases its ```DISABLE_CAP_MONITOR```, like https://github.com/NessieCircuits/Riotee_SDK/blob/ae1514a8685ff177c9d621a4cde6b418253daf11/core/runtime.c#L275 or https://github.com/NessieCircuits/Riotee_SDK/blob/ae1514a8685ff177c9d621a4cde6b418253daf11/core/runtime.c#L302

But its ```DISABLE_CAP_MON``` here: 
https://github.com/NessieCircuits/Riotee_SDK/blob/ae1514a8685ff177c9d621a4cde6b418253daf11/core/runtime.c#L248